### PR TITLE
Tailwind example: No need to truncate actual user address

### DIFF
--- a/examples/tailwindcss/components/wallet.tsx
+++ b/examples/tailwindcss/components/wallet.tsx
@@ -2,7 +2,7 @@
 
 import { MouseEventHandler, useEffect, useMemo } from 'react'
 import { ChainCard } from '../components'
-import { Address, truncate } from './react/views'
+import { Address } from './react/views'
 import {
   ArrowPathIcon,
   ArrowDownTrayIcon,
@@ -148,7 +148,7 @@ export const WalletSection = () => {
                 </div>
               )}
             </div>
-            {address ? <Address>{truncate(address)}</Address> : <></>}
+            {address ? <Address>{address}</Address> : <></>}
             <div className="w-full max-w-[52] md:max-w-[64]">
               {_renderConnectButton}
             </div>


### PR DESCRIPTION
Address is already truncated when rendering in the `<Address />` component.

However doing it here means the "copy to clipboard" functionality copies the truncated address which is incorrect.