### PR TITLE
ci: try immutable false for yarn4

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -22,7 +22,9 @@ jobs:
           cache: false
 
       - name: Install Dependencies
-        run: npm install -g create-cosmos-app
+        run: |
+          yarn config set -H enableImmutableInstalls false
+          npm install -g create-cosmos-app
 
       - name: asset-list
         run: |


### PR DESCRIPTION
This PR tries to fix CI error:

YN0028: │ The lockfile would have been modified by this install, which is explicitly forbidden.