### PR TITLE
add build:dev and docs

### DIFF
--- a/boilerplates/lerna-module/README.md
+++ b/boilerplates/lerna-module/README.md
@@ -24,7 +24,7 @@ When first cloning the repo:
 
 ```sh
 yarn
-# build the prod packages, this will navigate from references to their definitions (.d.ts files) between packages.
+# build the prod packages. When devs would like to navigate to the source code, this will only navigate from references to their definitions (.d.ts files) between packages.
 yarn build
 ```
 
@@ -32,7 +32,7 @@ Or if you want to make your dev process smoother, you can run:
 
 ```sh
 yarn
-# build the dev packages, this enables navigation from references to their source code between packages.
+# build the dev packages with .map files, this enables navigation from references to their source code between packages.
 yarn build:dev
 ```
 

--- a/boilerplates/lerna-module/README.md
+++ b/boilerplates/lerna-module/README.md
@@ -22,9 +22,18 @@ npm install __MODULENAME__
 
 When first cloning the repo:
 
-```
+```sh
 yarn
+# build the prod packages, this will navigate from references to their definitions (.d.ts files) between packages.
 yarn build
+```
+
+Or if you want to make your dev process smoother, you can run:
+
+```sh
+yarn
+# build the dev packages, this enables navigation from references to their source code between packages.
+yarn build:dev
 ```
 
 ## Related

--- a/boilerplates/lerna-module/package.json
+++ b/boilerplates/lerna-module/package.json
@@ -24,6 +24,7 @@
     "clean": "rimraf dist/**",
     "prepare": "npm run build",
     "build": "npm run clean; tsc; tsc -p tsconfig.esm.json; npm run copy",
+    "build:dev": "npm run clean; tsc --declarationMap; tsc -p tsconfig.esm.json; npm run copy",
     "lint": "eslint . --fix",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/boilerplates/lerna-workspace/README.md
+++ b/boilerplates/lerna-workspace/README.md
@@ -20,11 +20,20 @@ npm install __MODULENAME__
 
 ## Developing
 
-
 When first cloning the repo:
-```
+
+```sh
 yarn
+# build the prod packages, this will navigate from references to their definitions (.d.ts files) between packages.
 yarn build
+```
+
+Or if you want to make your dev process smoother, you can run:
+
+```sh
+yarn
+# build the dev packages, this enables navigation from references to their source code between packages.
+yarn build:dev
 ```
 
 ## Related

--- a/boilerplates/lerna-workspace/README.md
+++ b/boilerplates/lerna-workspace/README.md
@@ -24,7 +24,7 @@ When first cloning the repo:
 
 ```sh
 yarn
-# build the prod packages, this will navigate from references to their definitions (.d.ts files) between packages.
+# build the prod packages. When devs would like to navigate to the source code, this will only navigate from references to their definitions (.d.ts files) between packages.
 yarn build
 ```
 
@@ -32,7 +32,7 @@ Or if you want to make your dev process smoother, you can run:
 
 ```sh
 yarn
-# build the dev packages, this enables navigation from references to their source code between packages.
+# build the dev packages with .map files, this enables navigation from references to their source code between packages.
 yarn build:dev
 ```
 

--- a/boilerplates/lerna-workspace/package.json
+++ b/boilerplates/lerna-workspace/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "clean": "lerna run clean",
     "build": "lerna run build --stream",
+    "build:dev": "lerna run build:dev --stream; yarn symlink",
     "lint": "lerna run lint --parallel",
     "symlink": "symlink-workspace --logLevel error",
     "postinstall": "yarn symlink"


### PR DESCRIPTION
Add build:dev to enable devs to navigate from references to their source code instead of definations(.d.ts files).