### PR TITLE
docs: add deprecation notice to all README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 # create-cosmos-app
 
 <p align="center" width="100%">

--- a/boilerplates/lerna-module/README.md
+++ b/boilerplates/lerna-module/README.md
@@ -1,3 +1,9 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 # __MODULENAME__
 
 <p align="center">

--- a/boilerplates/lerna-tsx-module/README.md
+++ b/boilerplates/lerna-tsx-module/README.md
@@ -1,3 +1,9 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 # __MODULENAME__
 
 <p align="center">

--- a/boilerplates/lerna-workspace/README.md
+++ b/boilerplates/lerna-workspace/README.md
@@ -1,3 +1,9 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 # __MODULENAME__
 
 <p align="center">

--- a/boilerplates/npm-boilerplate/README.md
+++ b/boilerplates/npm-boilerplate/README.md
@@ -1,1 +1,7 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 # __PACKAGE_IDENTIFIER__

--- a/boilerplates/telescope/README.md
+++ b/boilerplates/telescope/README.md
@@ -1,3 +1,9 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 # __PACKAGE_IDENTIFIER__
 
 <p align="center">

--- a/boilerplates/ts-codegen-npm-module/README.md
+++ b/boilerplates/ts-codegen-npm-module/README.md
@@ -1,3 +1,9 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 # __MODULENAME__
 
 <p align="center">

--- a/boilerplates/ts-codegen-npm-module/contracts/stargaze-minter/README.md
+++ b/boilerplates/ts-codegen-npm-module/contracts/stargaze-minter/README.md
@@ -1,1 +1,7 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 # Stargaze minter

--- a/boilerplates/ts-codegen-npm-module/contracts/stargaze-sg721/README.md
+++ b/boilerplates/ts-codegen-npm-module/contracts/stargaze-sg721/README.md
@@ -1,1 +1,7 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 # Stargaze sg721

--- a/boilerplates/website/README.md
+++ b/boilerplates/website/README.md
@@ -1,3 +1,9 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 This is a Cosmos App project bootstrapped with [`create-cosmos-app`](https://github.com/hyperweb-io/create-cosmos-app).
 
 ## Getting Started

--- a/examples/authz/README.md
+++ b/examples/authz/README.md
@@ -1,3 +1,9 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 This is a Cosmos App project bootstrapped with [`create-cosmos-app`](https://github.com/hyperweb-io/create-cosmos-app).
 
 ## Getting Started

--- a/examples/authz/proto/confio/README.md
+++ b/examples/authz/proto/confio/README.md
@@ -1,1 +1,7 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 # confio

--- a/examples/authz/proto/cosmos/README.md
+++ b/examples/authz/proto/cosmos/README.md
@@ -1,1 +1,7 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+>
 # cosmos

--- a/examples/authz/proto/cosmos_proto/README.md
+++ b/examples/authz/proto/cosmos_proto/README.md
@@ -1,1 +1,7 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 # cosmos_proto

--- a/examples/authz/proto/cosmwasm/README.md
+++ b/examples/authz/proto/cosmwasm/README.md
@@ -1,1 +1,7 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 # cosmwasm

--- a/examples/authz/proto/gogoproto/README.md
+++ b/examples/authz/proto/gogoproto/README.md
@@ -1,1 +1,7 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+> 
 # gogoproto

--- a/examples/authz/proto/google/README.md
+++ b/examples/authz/proto/google/README.md
@@ -1,1 +1,7 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 # google

--- a/examples/authz/proto/ibc/README.md
+++ b/examples/authz/proto/ibc/README.md
@@ -1,1 +1,7 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 # ibc

--- a/examples/authz/proto/tendermint/README.md
+++ b/examples/authz/proto/tendermint/README.md
@@ -1,1 +1,7 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 # tendermint

--- a/examples/grpc-web-grpc-gateway/README.md
+++ b/examples/grpc-web-grpc-gateway/README.md
@@ -1,3 +1,9 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 This is a Cosmos App project bootstrapped with [`create-cosmos-app`](https://github.com/hyperweb-io/create-cosmos-app).
 
 ## Getting Started

--- a/examples/ibc-asset-list/README.md
+++ b/examples/ibc-asset-list/README.md
@@ -1,3 +1,9 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 This is a Cosmos App project bootstrapped with [`create-cosmos-app`](https://github.com/hyperweb-io/create-cosmos-app).
 
 ## Getting Started

--- a/examples/nft/README.md
+++ b/examples/nft/README.md
@@ -1,3 +1,9 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 This is a Cosmos App project bootstrapped with [`create-cosmos-app`](https://github.com/hyperweb-io/create-cosmos-app).
 
 ## Getting Started

--- a/examples/provide-liquidity/README.md
+++ b/examples/provide-liquidity/README.md
@@ -1,3 +1,9 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 This is a Cosmos App project bootstrapped with [`create-cosmos-app`](https://github.com/hyperweb-io/create-cosmos-app).
 
 ## Getting Started

--- a/examples/rollkit/README.md
+++ b/examples/rollkit/README.md
@@ -1,3 +1,9 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 This is a Cosmos App project bootstrapped with [`create-cosmos-app`](https://github.com/hyperweb-io/create-cosmos-app).
 
 ## Getting Started

--- a/examples/spawn/README.md
+++ b/examples/spawn/README.md
@@ -1,3 +1,9 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 This is a Cosmos App project bootstrapped with [`create-cosmos-app`](https://github.com/hyperweb-io/create-cosmos-app).
 
 ## Getting Started

--- a/examples/stake-tokens/README.md
+++ b/examples/stake-tokens/README.md
@@ -1,3 +1,9 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 This is a Cosmos App project bootstrapped with [`create-cosmos-app`](https://github.com/hyperweb-io/create-cosmos-app).
 
 ## Getting Started

--- a/examples/swap-tokens/README.md
+++ b/examples/swap-tokens/README.md
@@ -1,3 +1,9 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 This is a Cosmos App project bootstrapped with [`create-cosmos-app`](https://github.com/hyperweb-io/create-cosmos-app).
 
 ## Getting Started

--- a/examples/telescope-with-contracts/README.md
+++ b/examples/telescope-with-contracts/README.md
@@ -1,3 +1,9 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 This is a Cosmos App project bootstrapped with [`create-cosmos-app`](https://github.com/hyperweb-io/create-cosmos-app).
 
 ## Getting Started

--- a/examples/telescope-with-contracts/proto/confio/README.md
+++ b/examples/telescope-with-contracts/proto/confio/README.md
@@ -1,1 +1,7 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 # confio

--- a/examples/telescope-with-contracts/proto/cosmos/README.md
+++ b/examples/telescope-with-contracts/proto/cosmos/README.md
@@ -1,1 +1,7 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 # cosmos

--- a/examples/telescope-with-contracts/proto/cosmos_proto/README.md
+++ b/examples/telescope-with-contracts/proto/cosmos_proto/README.md
@@ -1,1 +1,6 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
 # cosmos_proto

--- a/examples/telescope-with-contracts/proto/cosmwasm/README.md
+++ b/examples/telescope-with-contracts/proto/cosmwasm/README.md
@@ -1,1 +1,7 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 # cosmwasm

--- a/examples/telescope-with-contracts/proto/gogoproto/README.md
+++ b/examples/telescope-with-contracts/proto/gogoproto/README.md
@@ -1,1 +1,6 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
 # gogoproto

--- a/examples/telescope-with-contracts/proto/google/README.md
+++ b/examples/telescope-with-contracts/proto/google/README.md
@@ -1,1 +1,7 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 # google

--- a/examples/telescope-with-contracts/proto/ibc/README.md
+++ b/examples/telescope-with-contracts/proto/ibc/README.md
@@ -1,1 +1,7 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 # ibc

--- a/examples/telescope-with-contracts/proto/tendermint/README.md
+++ b/examples/telescope-with-contracts/proto/tendermint/README.md
@@ -1,1 +1,7 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 # tendermint

--- a/examples/telescope/README.md
+++ b/examples/telescope/README.md
@@ -1,3 +1,9 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 This is a Cosmos App project bootstrapped with [`create-cosmos-app`](https://github.com/hyperweb-io/create-cosmos-app).
 
 ## Getting Started

--- a/examples/telescope/proto/confio/README.md
+++ b/examples/telescope/proto/confio/README.md
@@ -1,1 +1,7 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 # confio

--- a/examples/telescope/proto/cosmos/README.md
+++ b/examples/telescope/proto/cosmos/README.md
@@ -1,1 +1,7 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+> 
 # cosmos

--- a/examples/telescope/proto/cosmos_proto/README.md
+++ b/examples/telescope/proto/cosmos_proto/README.md
@@ -1,1 +1,7 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 # cosmos_proto

--- a/examples/telescope/proto/cosmwasm/README.md
+++ b/examples/telescope/proto/cosmwasm/README.md
@@ -1,1 +1,7 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 # cosmwasm

--- a/examples/telescope/proto/gogoproto/README.md
+++ b/examples/telescope/proto/gogoproto/README.md
@@ -1,1 +1,7 @@
-# gogoproto
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+> 
+> # gogoproto

--- a/examples/telescope/proto/google/README.md
+++ b/examples/telescope/proto/google/README.md
@@ -1,1 +1,7 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 # google

--- a/examples/telescope/proto/ibc/README.md
+++ b/examples/telescope/proto/ibc/README.md
@@ -1,1 +1,7 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 # ibc

--- a/examples/telescope/proto/tendermint/README.md
+++ b/examples/telescope/proto/tendermint/README.md
@@ -1,1 +1,7 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 # tendermint

--- a/examples/vote-proposal/README.md
+++ b/examples/vote-proposal/README.md
@@ -1,3 +1,9 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 This is a Cosmos App project bootstrapped with [`create-cosmos-app`](https://github.com/hyperweb-io/create-cosmos-app).
 
 ## Getting Started

--- a/packages/create-cosmos-app/README.md
+++ b/packages/create-cosmos-app/README.md
@@ -1,3 +1,9 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 # create-cosmos-app
 
 <p align="center" width="100%">

--- a/templates/chain-template/README.md
+++ b/templates/chain-template/README.md
@@ -1,3 +1,9 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 This is a Cosmos App project bootstrapped with [`create-cosmos-app`](https://github.com/hyperweb-io/create-cosmos-app).
 
 ## Getting Started

--- a/templates/connect-chain/README.md
+++ b/templates/connect-chain/README.md
@@ -1,3 +1,9 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 This is a Cosmos App project bootstrapped with [`create-cosmos-app`](https://github.com/hyperweb-io/create-cosmos-app).
 
 ## Getting Started

--- a/templates/connect-multi-chain/README.md
+++ b/templates/connect-multi-chain/README.md
@@ -1,3 +1,9 @@
+> **⚠️ DEPRECATION NOTICE**
+> 
+> **This package is deprecated and no longer maintained.** 
+> 
+> Please use [**create-interchain-app**](https://github.com/hyperweb-io/create-interchain-app) instead, which provides the latest features and improvements for building Interchain applications.
+
 This is a Cosmos App project bootstrapped with [`create-cosmos-app`](https://github.com/hyperweb-io/create-cosmos-app).
 
 ## Getting Started


### PR DESCRIPTION
Add warning message directing users to create-interchain-app as the maintained alternative across all project documentation.